### PR TITLE
Guess thumbnail type from original image name

### DIFF
--- a/imageprocessor/gm/gm.go
+++ b/imageprocessor/gm/gm.go
@@ -6,10 +6,16 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
+	"strings"
 	"time"
 )
 
 const GM_COMMAND = "convert"
+
+func fileExtension(filename string) string {
+	pieces := strings.Split(filename, ".")
+	return pieces[len(pieces)-1]
+}
 
 func ConvertToJpeg(filename string) (string, error) {
 	outfile := fmt.Sprintf("%s_jpg", filename)
@@ -100,7 +106,7 @@ func SquareThumb(filename, name string, size int) (string, error) {
 		"72x72",
 		"-unsharp",
 		"0.5",
-		fmt.Sprintf("JPG:%s", outfile),
+		fmt.Sprintf("%s:%s", fileExtension(filename), outfile),
 	}
 
 	err := runConvertCommand(args)
@@ -122,7 +128,7 @@ func Thumb(filename, name string, width, height int) (string, error) {
 		fmt.Sprintf("%dx%d>", width, height),
 		"-density",
 		"72x72",
-		fmt.Sprintf("JPG:%s", outfile),
+		fmt.Sprintf("%s:%s", fileExtension(filename), outfile),
 	}
 
 	err := runConvertCommand(args)

--- a/imageprocessor/gm/gm.go
+++ b/imageprocessor/gm/gm.go
@@ -12,9 +12,20 @@ import (
 
 const GM_COMMAND = "convert"
 
+func supportedFormats() []string {
+	return []string{"gif", "jpg", "png"}
+}
+
 func fileExtension(filename string) string {
 	pieces := strings.Split(filename, ".")
-	return pieces[len(pieces)-1]
+	ext := pieces[len(pieces)-1]
+	for _, format := range supportedFormats() {
+		if strings.EqualFold(format, ext) {
+			return format
+		}
+	}
+
+	return "jpg"
 }
 
 func ConvertToJpeg(filename string) (string, error) {

--- a/imageprocessor/gm/gm.go
+++ b/imageprocessor/gm/gm.go
@@ -16,7 +16,9 @@ func supportedFormats() []string {
 	return []string{"gif", "jpg", "png"}
 }
 
-func fileExtension(filename string) string {
+// Gets the most appropriate file extension for
+// the given image filename.
+func getExtension(filename string) string {
 	pieces := strings.Split(filename, ".")
 	ext := pieces[len(pieces)-1]
 	for _, format := range supportedFormats() {
@@ -117,7 +119,7 @@ func SquareThumb(filename, name string, size int) (string, error) {
 		"72x72",
 		"-unsharp",
 		"0.5",
-		fmt.Sprintf("%s:%s", fileExtension(filename), outfile),
+		fmt.Sprintf("%s:%s", getExtension(filename), outfile),
 	}
 
 	err := runConvertCommand(args)
@@ -139,7 +141,7 @@ func Thumb(filename, name string, width, height int) (string, error) {
 		fmt.Sprintf("%dx%d>", width, height),
 		"-density",
 		"72x72",
-		fmt.Sprintf("%s:%s", fileExtension(filename), outfile),
+		fmt.Sprintf("%s:%s", getExtension(filename), outfile),
 	}
 
 	err := runConvertCommand(args)

--- a/imageprocessor/gm/gm.go
+++ b/imageprocessor/gm/gm.go
@@ -6,29 +6,12 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
-	"strings"
 	"time"
+
+	"github.com/Imgur/mandible/imageprocessor/thumbType"
 )
 
 const GM_COMMAND = "convert"
-
-func supportedFormats() []string {
-	return []string{"gif", "jpg", "png"}
-}
-
-// Gets the most appropriate file extension for
-// the given image filename.
-func getExtension(filename string) string {
-	pieces := strings.Split(filename, ".")
-	ext := pieces[len(pieces)-1]
-	for _, format := range supportedFormats() {
-		if strings.EqualFold(format, ext) {
-			return format
-		}
-	}
-
-	return "jpg"
-}
 
 func ConvertToJpeg(filename string) (string, error) {
 	outfile := fmt.Sprintf("%s_jpg", filename)
@@ -102,7 +85,7 @@ func ResizePercent(filename string, percent int) (string, error) {
 	return outfile, nil
 }
 
-func SquareThumb(filename, name string, size int) (string, error) {
+func SquareThumb(filename, name string, size int, format thumbType.ThumbType) (string, error) {
 	outfile := fmt.Sprintf("%s_%s", filename, name)
 
 	args := []string{
@@ -119,7 +102,7 @@ func SquareThumb(filename, name string, size int) (string, error) {
 		"72x72",
 		"-unsharp",
 		"0.5",
-		fmt.Sprintf("%s:%s", getExtension(filename), outfile),
+		fmt.Sprintf("%s:%s", format.ToString(), outfile),
 	}
 
 	err := runConvertCommand(args)
@@ -130,7 +113,7 @@ func SquareThumb(filename, name string, size int) (string, error) {
 	return outfile, nil
 }
 
-func Thumb(filename, name string, width, height int) (string, error) {
+func Thumb(filename, name string, width, height int, format thumbType.ThumbType) (string, error) {
 	outfile := fmt.Sprintf("%s_%s", filename, name)
 
 	args := []string{
@@ -141,7 +124,7 @@ func Thumb(filename, name string, width, height int) (string, error) {
 		fmt.Sprintf("%dx%d>", width, height),
 		"-density",
 		"72x72",
-		fmt.Sprintf("%s:%s", getExtension(filename), outfile),
+		fmt.Sprintf("%s:%s", format.ToString(), outfile),
 	}
 
 	err := runConvertCommand(args)
@@ -152,10 +135,10 @@ func Thumb(filename, name string, width, height int) (string, error) {
 	return outfile, nil
 }
 
-func CircleThumb(filename, name string, width int) (string, error) {
+func CircleThumb(filename, name string, width int, format thumbType.ThumbType) (string, error) {
 	outfile := fmt.Sprintf("%s_%s", filename, name)
 
-	filename, err := Thumb(filename, name, width*2, width*2)
+	filename, err := Thumb(filename, name, width*2, width*2, format)
 	if err != nil {
 		return "", err
 	}
@@ -172,7 +155,7 @@ func CircleThumb(filename, name string, width int) (string, error) {
 		"72x72",
 		"-draw",
 		fmt.Sprintf("circle %d,%d %d,1", width/2, width/2, width/2),
-		fmt.Sprintf("PNG:%s", outfile),
+		fmt.Sprintf("%s:%s", format.ToString(), outfile),
 	}
 
 	err = runConvertCommand(args)

--- a/imageprocessor/thumbType/thumbType.go
+++ b/imageprocessor/thumbType/thumbType.go
@@ -16,3 +16,13 @@ func (this ThumbType) ToString() string {
     return "JPG"
   }
 }
+
+func FromMime(mime string) ThumbType {
+  if mime == "image/gif" {
+    return GIF
+  } else if mime == "image/png" {
+    return PNG
+  } else {
+    return JPG
+  }
+}

--- a/imageprocessor/thumbType/thumbType.go
+++ b/imageprocessor/thumbType/thumbType.go
@@ -1,0 +1,18 @@
+package thumbType
+
+type ThumbType int
+const (
+  JPG ThumbType = iota
+  PNG
+  GIF
+)
+
+func (this ThumbType) ToString() string {
+  if this == PNG {
+    return "PNG"
+  } else if this == GIF {
+    return "GIF"
+  } else {
+    return "JPG"
+  }
+}

--- a/imageprocessor/thumbType/thumbType.go
+++ b/imageprocessor/thumbType/thumbType.go
@@ -1,28 +1,29 @@
 package thumbType
 
 type ThumbType int
+
 const (
-  JPG ThumbType = iota
-  PNG
-  GIF
+	JPG ThumbType = iota
+	PNG
+	GIF
 )
 
 func (this ThumbType) ToString() string {
-  if this == PNG {
-    return "PNG"
-  } else if this == GIF {
-    return "GIF"
-  } else {
-    return "JPG"
-  }
+	if this == PNG {
+		return "PNG"
+	} else if this == GIF {
+		return "GIF"
+	} else {
+		return "JPG"
+	}
 }
 
 func FromMime(mime string) ThumbType {
-  if mime == "image/gif" {
-    return GIF
-  } else if mime == "image/png" {
-    return PNG
-  } else {
-    return JPG
-  }
+	if mime == "image/gif" {
+		return GIF
+	} else if mime == "image/png" {
+		return PNG
+	} else {
+		return JPG
+	}
 }

--- a/uploadedfile/thumbfile.go
+++ b/uploadedfile/thumbfile.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/Imgur/mandible/imageprocessor/gm"
+	"github.com/Imgur/mandible/imageprocessor/thumbType"
 )
 
 type ThumbFile struct {
@@ -87,7 +88,7 @@ func (this *ThumbFile) Process(original *UploadedFile) error {
 }
 
 func (this *ThumbFile) processSquare(original *UploadedFile) error {
-	filename, err := gm.SquareThumb(original.GetPath(), this.GetName(), this.GetWidth())
+	filename, err := gm.SquareThumb(original.GetPath(), this.GetName(), this.GetWidth(), thumbType.FromMime(original.GetMime()))
 	if err != nil {
 		return err
 	}
@@ -100,7 +101,7 @@ func (this *ThumbFile) processSquare(original *UploadedFile) error {
 }
 
 func (this *ThumbFile) processCircle(original *UploadedFile) error {
-	filename, err := gm.CircleThumb(original.GetPath(), this.GetName(), this.GetWidth())
+	filename, err := gm.CircleThumb(original.GetPath(), this.GetName(), this.GetWidth(), thumbType.FromMime(original.GetMime()))
 	if err != nil {
 		return err
 	}
@@ -113,7 +114,7 @@ func (this *ThumbFile) processCircle(original *UploadedFile) error {
 }
 
 func (this *ThumbFile) processThumb(original *UploadedFile) error {
-	filename, err := gm.Thumb(original.GetPath(), this.GetName(), this.GetWidth(), this.GetHeight())
+	filename, err := gm.Thumb(original.GetPath(), this.GetName(), this.GetWidth(), this.GetHeight(), thumbType.FromMime(original.GetMime()))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request addresses issue #50 by guessing the most appropriate image type from the original filename's extension. If it can't match up with one of the supported types, it just falls back to JPG.