### PR TITLE
use imagemagick instead of graphicsmagick

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.4
 ENV PORT 80
 EXPOSE 80
-RUN apt-get update && apt-get install -yqq aspell aspell-en libaspell-dev tesseract-ocr tesseract-ocr-eng graphicsmagick graphicsmagick-imagemagick-compat optipng exiftool libjpeg-progs
+RUN apt-get update && apt-get install -yqq aspell aspell-en libaspell-dev tesseract-ocr tesseract-ocr-eng imagemagick optipng exiftool libjpeg-progs
 RUN wget https://github.com/johnlinp/meme-ocr/raw/master/tessdata/joh.traineddata -O /usr/share/tesseract-ocr/tessdata/meme.traineddata
 RUN mkdir -p /etc/mandible /tmp/imagestore
 ADD docker/conf.json /etc/mandible/conf.json


### PR DESCRIPTION
as it seems graphicmagick is not compatible with the processing args in:
https://github.com/Imgur/mandible/blob/master/imageprocessor/processorcommand/ocrcommands.go#L144

As seen in building the docker image:
```
convert: Unable to open file (#FFFFFF) [No such file or directory].
```
