### PR TITLE
Use `bucket.URL()` to generate url for an object.

### DIFF
--- a/imagestore/s3store.go
+++ b/imagestore/s3store.go
@@ -46,7 +46,7 @@ func (this *S3ImageStore) Save(src io.Reader, obj *StoreObject) (*StoreObject, e
 		return nil, err
 	}
 
-	obj.Url = "https://s3.amazonaws.com/" + this.bucketName + this.toPath(obj)
+	obj.Url = bucket.URL(this.toPath(obj))
 	return obj, nil
 }
 


### PR DESCRIPTION
We were trying to use a different aws region than us standard. And we had trouble with the resulting URL.

This patch will generate this URL dynamically using the s3 go package.