### PR TITLE
Support for Data URI scheme

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -264,7 +264,8 @@ func (s *Server) Configure(muxer *http.ServeMux) {
 	}
 
 	var extractorBase64 fileExtractor = func(r *http.Request) (uploadFile io.Reader, filename string, uerr *UserError) {
-		b64data := r.FormValue("image")
+		input := r.FormValue("image")
+		b64data := input[strings.IndexByte(input, ',')+1:]
 
 		uploadFile = base64.NewDecoder(base64.StdEncoding, strings.NewReader(b64data))
 


### PR DESCRIPTION
Currently it's always assumed that there is no data scheme information in the base64 payload. But having support for this is actually convenient because a lot of frameworks emit this format.

The Data URI scheme looks like this:
`data:[<MIME-type>][;charset=<encoding>][;base64],<data>`

This code change does not break previous behaviour where a base64 string was set as image parameter.

Also found this stackoverflow question which is kind of related: http://stackoverflow.com/questions/31031589/illegal-base64-data-at-input-byte-4-when-using-base64-stdencoding-decodestrings