### PR TITLE
Clean only if error is nil

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -115,7 +115,6 @@ func (s *Server) uploadFile(uploadFile io.Reader, fileName string, thumbs []*upl
 	}
 
 	upload, err := uploadedfile.NewUploadedFile(fileName, tmpFile, thumbs)
-	defer upload.Clean()
 
 	if err != nil {
 		return ServerResponse{
@@ -123,6 +122,7 @@ func (s *Server) uploadFile(uploadFile io.Reader, fileName string, thumbs []*upl
 			Status: http.StatusInternalServerError,
 		}
 	}
+	defer upload.Clean()
 
 	processor, err := s.processorStrategy(s.Config, upload)
 	if err != nil {


### PR DESCRIPTION
uploadedfile.NewUploadedFile always returns nil as first argument if error, therefore this code throws panic if we can't detect mime type. This PR fixes this behavior