### PR TITLE
update go and swap to graphicsmagic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang:1.5
-RUN apt-get update && apt-get install -yqq aspell aspell-en libaspell-dev tesseract-ocr tesseract-ocr-eng imagemagick optipng exiftool libjpeg-progs webp
+FROM golang:1.8
+RUN apt-get update && apt-get install -yqq aspell aspell-en libaspell-dev tesseract-ocr tesseract-ocr-eng graphicsmagick optipng exiftool libjpeg-progs webp
 ADD docker/meme.traineddata /usr/share/tesseract-ocr/tessdata/meme.traineddata
 ADD docker/imagemagick_policy.xml /etc/ImageMagick-6/policy.xml
 RUN mkdir -p /etc/mandible /tmp/imagestore

--- a/imageprocessor/processorcommand/gm.go
+++ b/imageprocessor/processorcommand/gm.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Imgur/mandible/imageprocessor/thumbType"
 )
 
-const GM_COMMAND = "convert"
+const GM_COMMAND = "gm convert"
 
 func ConvertToJpeg(filename string) (string, error) {
 	outfile := fmt.Sprintf("%s_jpg", filename)


### PR DESCRIPTION
- Updates go to 1.8

- Swaps to graphicsmagick `gm convert` instead of imagemagick