### PR TITLE
Revert "Use GraphicsMagick"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.8-stretch
-RUN apt-get update && apt-get install -yqq aspell aspell-en libaspell-dev tesseract-ocr tesseract-ocr-eng graphicsmagick optipng exiftool libjpeg-progs webp
+FROM golang:1.5
+RUN apt-get update && apt-get install -yqq aspell aspell-en libaspell-dev tesseract-ocr tesseract-ocr-eng imagemagick optipng exiftool libjpeg-progs webp
 ADD docker/meme.traineddata /usr/share/tesseract-ocr/tessdata/meme.traineddata
+ADD docker/imagemagick_policy.xml /etc/ImageMagick-6/policy.xml
 RUN mkdir -p /etc/mandible /tmp/imagestore
 ENV MANDIBLE_CONF /etc/mandible/conf.json
+ENV GO15VENDOREXPERIMENT 1
 ADD . /go/src/github.com/Imgur/mandible
 WORKDIR /go/src/github.com/Imgur/mandible
 RUN go get github.com/mattn/goveralls

--- a/docker/imagemagick_policy.xml
+++ b/docker/imagemagick_policy.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!ATTLIST policy domain (delegate|coder|filter|path|resource) #IMPLIED>
+<!ATTLIST policy name CDATA #IMPLIED>
+<!ATTLIST policy rights CDATA #IMPLIED>
+<!ATTLIST policy pattern CDATA #IMPLIED>
+<!ATTLIST policy value CDATA #IMPLIED>
+]>
+<!--
+  Configure ImageMagick policies.
+
+  Domains include system, delegate, coder, filter, path, or resource.
+
+  Rights include none, read, write, and execute.  Use | to combine them,
+  for example: "read | write" to permit read from, or write to, a path.
+
+  Use a glob expression as a pattern.
+
+  Suppose we do not want users to process MPEG video images:
+
+    <policy domain="delegate" rights="none" pattern="mpeg:decode" />
+
+  Here we do not want users reading images from HTTP:
+
+    <policy domain="coder" rights="none" pattern="HTTP" />
+
+  Lets prevent users from executing any image filters:
+
+    <policy domain="filter" rights="none" pattern="*" />
+
+  The /repository file system is restricted to read only.  We use a glob
+  expression to match all paths that start with /repository:
+
+    <policy domain="path" rights="read" pattern="/repository/*" />
+
+  Any large image is cached to disk rather than memory:
+
+    <policy domain="resource" name="area" value="1GB"/>
+
+  Define arguments for the memory, map, area, and disk resources with
+  SI prefixes (.e.g 100MB).  In addition, resource policies are maximums for
+  each instance of ImageMagick (e.g. policy memory limit 1GB, -limit 2GB
+  exceeds policy maximum so memory limit is 1GB).
+-->
+
+<policymap>
+  <policy domain="coder" rights="none" pattern="EPHEMERAL" />
+  <policy domain="coder" rights="none" pattern="URL" />
+  <policy domain="coder" rights="none" pattern="HTTPS" />
+  <policy domain="coder" rights="none" pattern="MVG" />
+  <policy domain="coder" rights="none" pattern="MSL" />
+  <policy domain="coder" rights="none" pattern="TEXT" />
+  <policy domain="coder" rights="none" pattern="SHOW" />
+  <policy domain="coder" rights="none" pattern="WIN" />
+  <policy domain="coder" rights="none" pattern="PLT" />
+  <policy domain="cache" name="shared-secret" value="passphrase"/>
+</policymap>

--- a/goclean.sh
+++ b/goclean.sh
@@ -39,5 +39,4 @@ done
 
 godep go tool cover -func profile.cov
 
-# This is breaking travis-ci. Disabling it for now.
-# [ ${COVERALLS_TOKEN} ] && goveralls -coverprofile=profile.cov -service travis-ci -repotoken $COVERALLS_TOKEN
+[ ${COVERALLS_TOKEN} ] && goveralls -coverprofile=profile.cov -service travis-ci -repotoken $COVERALLS_TOKEN

--- a/imageprocessor/ocr_test.go
+++ b/imageprocessor/ocr_test.go
@@ -25,20 +25,20 @@ func TestStandardOCR(t *testing.T) {
 	}
 }
 
-// func TestDuelOCR(t *testing.T) {
-// 	image, err := getUploadedFileObject()
-// 	if err != nil {
-// 		t.Fatalf("Could not initialize standard OCR test")
-// 	}
-// 	defer image.Clean()
-//
-// 	ocrStratagy := DuelOCRStratagy()
-// 	ocrStratagy.Process(image)
-//
-// 	if image.GetOCRText() != "hello" {
-// 		t.Fatalf("Did not get proper Duel OCR text back %s != hello", image.GetOCRText())
-// 	}
-// }
+func TestDuelOCR(t *testing.T) {
+	image, err := getUploadedFileObject()
+	if err != nil {
+		t.Fatalf("Could not initialize standard OCR test")
+	}
+	defer image.Clean()
+
+	ocrStratagy := DuelOCRStratagy()
+	ocrStratagy.Process(image)
+
+	if image.GetOCRText() != "hello" {
+		t.Fatalf("Did not get proper Duel OCR text back %s != hello", image.GetOCRText())
+	}
+}
 
 func getUploadedFileObject() (*uploadedfile.UploadedFile, error) {
 	filename, err := copyTestImage("testdata/ocrtestimage.png")

--- a/imageprocessor/processorcommand/gm.go
+++ b/imageprocessor/processorcommand/gm.go
@@ -6,13 +6,12 @@ import (
 	"github.com/Imgur/mandible/imageprocessor/thumbType"
 )
 
-const GM_COMMAND = "gm"
+const GM_COMMAND = "convert"
 
 func ConvertToJpeg(filename string) (string, error) {
 	outfile := fmt.Sprintf("%s_jpg", filename)
 
 	args := []string{
-		"convert",
 		filename,
 		"-flatten",
 		"JPEG:" + outfile,
@@ -30,7 +29,6 @@ func FixOrientation(filename string) (string, error) {
 	outfile := fmt.Sprintf("%s_ort", filename)
 
 	args := []string{
-		"convert",
 		filename,
 		"-auto-orient",
 		outfile,
@@ -48,7 +46,6 @@ func Quality(filename string, quality int) (string, error) {
 	outfile := fmt.Sprintf("%s_q", filename)
 
 	args := []string{
-		"convert",
 		filename,
 		"-quality",
 		fmt.Sprintf("%d", quality),
@@ -69,7 +66,6 @@ func ResizePercent(filename string, percent int) (string, error) {
 	outfile := fmt.Sprintf("%s_rp", filename)
 
 	args := []string{
-		"convert",
 		filename,
 		"-resize",
 		fmt.Sprintf("%d%%", percent),
@@ -88,7 +84,6 @@ func SquareThumb(filename, name string, size int, quality int, format thumbType.
 	outfile := fmt.Sprintf("%s_%s", filename, name)
 
 	args := []string{
-		"convert",
 		fmt.Sprintf("%s[0]", filename),
 		"-resize",
 		fmt.Sprintf("%dx%d^", size, size),
@@ -123,7 +118,6 @@ func Thumb(filename, name string, width, height int, quality int, format thumbTy
 	outfile := fmt.Sprintf("%s_%s", filename, name)
 
 	args := []string{
-		"convert",
 		fmt.Sprintf("%s[0]", filename),
 		"-resize",
 		fmt.Sprintf("%dx%d>", width, height),
@@ -157,7 +151,6 @@ func CircleThumb(filename, name string, width int, quality int, format thumbType
 	}
 
 	args := []string{
-		"convert",
 		"-size",
 		fmt.Sprintf("%dx%d", width, width),
 		"xc:none",
@@ -192,7 +185,6 @@ func CustomThumb(filename, name string, width, height int, cropGravity string, c
 	outfile := fmt.Sprintf("%s_%s", filename, name)
 
 	args := []string{
-		"convert",
 		fmt.Sprintf("%s[0]", filename),
 		"-resize",
 		fmt.Sprintf("%dx%d^", width, height),
@@ -229,7 +221,6 @@ func Full(filename string, name string, quality int, format thumbType.ThumbType)
 	outfile := fmt.Sprintf("%s_%s", filename, name)
 
 	args := []string{
-		"convert",
 		fmt.Sprintf("%s[0]", filename),
 		"-density",
 		"72x72",

--- a/imageprocessor/processorcommand/ocrcommands.go
+++ b/imageprocessor/processorcommand/ocrcommands.go
@@ -130,7 +130,7 @@ func (this *MemeOCR) Run(image string) (*OCRResult, error) {
 	imageTif := fmt.Sprintf("%s_meme.jpg", image)
 	outText := fmt.Sprintf("%s_meme", image)
 	inImage := fmt.Sprintf("%s[0]", image)
-	preprocessingArgs := []string{"convert", inImage, "-resize", "400%", "-fill", "black", "-fuzz", "10%", "+matte", "-matte", "-transparent", "white", imageTif}
+	preprocessingArgs := []string{inImage, "-resize", "400%", "-fill", "black", "-fuzz", "10%", "+opaque", "#FFFFFF", imageTif}
 	tesseractArgs := []string{"-l", "meme", imageTif, outText}
 
 	err := runProcessorCommand(GM_COMMAND, preprocessingArgs)
@@ -169,7 +169,7 @@ func (this *StandardOCR) Run(image string) (*OCRResult, error) {
 	imageTif := fmt.Sprintf("%s_standard.jpg", image)
 	outText := fmt.Sprintf("%s_standard", image)
 	inImage := fmt.Sprintf("%s[0]", image)
-	preprocessingArgs := []string{"convert", inImage, "-resize", "400%", "-type", "Grayscale", imageTif}
+	preprocessingArgs := []string{inImage, "-resize", "400%", "-type", "Grayscale", imageTif}
 	tesseractArgs := []string{"-l", "eng", imageTif, outText}
 
 	err := runProcessorCommand(GM_COMMAND, preprocessingArgs)


### PR DESCRIPTION
Reverts Imgur/mandible#111

**Details:**
GM is failing for certain gifs.
http://graphicsmagick-help.narkive.com/y5AAvruT/gm-help-corrupt-image-when-gm-deals-with-gif
```
$ gm identify error.gifÂ 
gm identify: Corrupt image (error.gif).
gm identify: Request did not return an image.
What is the origin of this GIF file? GM reports that there is a LZW
string table overflow.

There have been exploits where GIF files were updated by virus
software to produce files with oversized LZW tables in order to
compromise the software (e.g. execute code provided in the image file
or crash the program) which opened them.

ImageMagick was re-coded to skip over the extra data in oversized LZW
tables.

In some cases, oversized LZW tables could be due to a bug in the
writing software, or it could be an effort to use larger tables
than allowed by the specification, but in other cases it is
intentional and could be suspect.
```

@pastudan 